### PR TITLE
Various Tweaks

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -70,7 +70,7 @@
 
         {{-- Ghost Variant --}}
         'text-primary-500 hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-600/40 dark:hover:text-primary-100' => Color::Primary->is($color) && Variant::Ghost->is($variant),
-        'text-secondary-500 hover:bg-secondary-300/50 hover:text-secondary-700 dark:text-secondary-300 dark:hover:bg-secondary-600/40 dark:hover:text-secondary-100' => Color::Secondary->is($color) && Variant::Ghost->is($variant),
+        'text-secondary-500 hover:bg-secondary-300/20 hover:text-secondary-700 dark:text-secondary-300 dark:hover:bg-secondary-600/40 dark:hover:text-secondary-100' => Color::Secondary->is($color) && Variant::Ghost->is($variant),
         'text-success-500 hover:bg-success-50 dark:text-success-400 dark:hover:bg-success-600/40 dark:hover:text-success-100' => Color::Success->is($color) && Variant::Ghost->is($variant),
         'text-warning-500 hover:bg-warning-50 dark:text-warning-400 dark:hover:bg-warning-600/40 dark:hover:text-warning-100' => Color::Warning->is($color) && Variant::Ghost->is($variant),
         'text-error-500 hover:bg-error-50 dark:text-error-400 dark:hover:bg-error-600/40 dark:hover:text-error-100' => Color::Error->is($color) && Variant::Ghost->is($variant),

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -6,6 +6,7 @@
     'size' => Size::BASE,
     'radius' => Size::BASE,
     'variant' => Variant::Outline,
+    'padding' => true,
 ])
 
 <div {{ $attributes->class([
@@ -109,10 +110,10 @@
 
     {{-- Main Content --}}
     <div @class([
-        'px-3 py-1.5 text-sm' => Size::SM->is($size),
-        'px-4 py-2' => Size::BASE->is($size),
-        'px-5 py-2.5' => Size::MD->is($size),
-        'px-6 py-3 text-lg' => Size::LG->is($size),
+        'px-3 py-1.5 text-sm' => $padding === true && Size::SM->is($size),
+        'px-4 py-2' => $padding === true && Size::BASE->is($size),
+        'px-5 py-2.5' => $padding === true && Size::MD->is($size),
+        'px-6 py-3 text-lg' => $padding === true && Size::LG->is($size),
     ])>{{ $slot }}</div>
 
     {{-- Footer --}}

--- a/resources/views/components/description.blade.php
+++ b/resources/views/components/description.blade.php
@@ -1,14 +1,13 @@
 @use('Bearly\Ui\Size')
-
 @props([
     'size' => Size::BASE,
+    'tag' => 'p',
 ])
-
-<p {{ $attributes->class([
+<{{ $tag }} {{ $attributes->class([
     'opacity-60',
     'text-xs [[data-ui-heading]+&]:mt-1' => Size::SM->is($size),
     'text-sm [[data-ui-heading]+&]:mt-2' => Size::BASE->is($size),
     'text-base [[data-ui-heading]+&]:mt-3' => Size::MD->is($size),
     'text-base font-light [[data-ui-heading]+&]:mt-3' => Size::LG->is($size),
     'text-lg font-extralight [[data-ui-heading]+&]:mt-3' => Size::XL->is($size),
-]) }}>{{ $slot }}</p>
+]) }}>{{ $slot }}</{{ $tag }}>

--- a/resources/views/components/description.blade.php
+++ b/resources/views/components/description.blade.php
@@ -6,6 +6,7 @@
 
 <p {{ $attributes->class([
     'opacity-60',
+    'text-xs [[data-ui-heading]+&]:mt-1' => Size::SM->is($size),
     'text-sm [[data-ui-heading]+&]:mt-2' => Size::BASE->is($size),
     'text-base [[data-ui-heading]+&]:mt-3' => Size::MD->is($size),
     'text-base font-light [[data-ui-heading]+&]:mt-3' => Size::LG->is($size),

--- a/resources/views/components/heading.blade.php
+++ b/resources/views/components/heading.blade.php
@@ -6,10 +6,9 @@
 ])
 
 <{{ $tag }} data-ui-heading {{ $attributes->class([
-    'ui-heading', // Needed for the description component to add margin top
     'text-gray-700 dark:text-gray-300',
     'text-lg tracking-[-0.015em] font-medium' => Size::BASE->is($size),
     'text-xl tracking-tight font-medium' => Size::MD->is($size),
-    'text-xl tracking-tight font-bold' => Size::LG->is($size),
+    'text-xl tracking-tight font-semibold' => Size::LG->is($size),
     'text-2xl tracking-tighter font-extrabold' => Size::XL->is($size),
 ]) }}>{{ $slot }}</{{ $tag }}>

--- a/resources/views/components/link.blade.php
+++ b/resources/views/components/link.blade.php
@@ -3,7 +3,9 @@
     'href' => null,
 ])
 
-<a {{ $attributes->when(
-    $when === true && $href !== null,
-    fn ($attributes) => $attributes->merge(['href' => $href])
-) }}>{{ $slot }}</a>
+<a {{ $attributes
+    ->when(
+        $when === true && $href !== null,
+        fn ($attributes) => $attributes->merge(['href' => $href])
+    )
+}}>{{ $slot }}</a>

--- a/resources/views/components/link.blade.php
+++ b/resources/views/components/link.blade.php
@@ -1,0 +1,9 @@
+@props([
+    'when' => true,
+    'href' => null,
+])
+
+<a {{ $attributes->when(
+    $when === true && $href !== null,
+    fn ($attributes) => $attributes->merge(['href' => $href])
+) }}>{{ $slot }}</a>

--- a/resources/views/components/tile.blade.php
+++ b/resources/views/components/tile.blade.php
@@ -1,5 +1,10 @@
+@use('Bearly\Ui\Variant')
+@aware(['variant' => Variant::Solid])
 <div @class([
-    'flex-1 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8'
+    'flex-1 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 px-4 py-10 sm:px-6 xl:px-8',
+    'bg-white dark:bg-gray-900/50' => Variant::Solid->is($variant),
+    'bg-white border border-gray-900/10 dark:border-white/5' => Variant::Outline->is($variant),
+    'bg-transparent' => Variant::Ghost->is($variant),
 ])>
     @if (!empty($label))
         <ui:description tag="dt" :attributes="$label->attributes->class([

--- a/resources/views/components/tile.blade.php
+++ b/resources/views/components/tile.blade.php
@@ -1,7 +1,13 @@
+@use('Bearly\Ui\Size')
 @use('Bearly\Ui\Variant')
-@aware(['variant' => Variant::Solid])
+
+@aware([
+    'variant' => Variant::Solid
+])
+
 <div @class([
-    'flex-1 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 px-4 py-10 sm:px-6 xl:px-8',
+    'flex-1 flex flex-wrap items-baseline justify-between',
+    'gap-y-2 px-2 py-6 sm:px-6 xl:px-8',
     'bg-white dark:bg-gray-900/50' => Variant::Solid->is($variant),
     'bg-white border border-gray-900/10 dark:border-white/5' => Variant::Outline->is($variant),
     'bg-transparent' => Variant::Ghost->is($variant),

--- a/resources/views/components/tile/index.blade.php
+++ b/resources/views/components/tile/index.blade.php
@@ -1,0 +1,19 @@
+<div @class([
+    'flex-1 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8'
+])>
+    @if (!empty($label))
+        <dt {{ $label->attributes->class(['text-sm font-medium leading-6 text-gray-500']) }}>
+            {{ $label }}
+        </dt>
+    @endif
+
+    @if (!empty($description))
+        <dd {{ $description->attributes->class(['text-xs font-medium text-gray-700']) }}>
+            {{ $description }}
+        </dd>
+    @endif
+
+    <dd class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900">
+        {{ $slot }}
+    </dd>
+</div>

--- a/resources/views/components/tile/index.blade.php
+++ b/resources/views/components/tile/index.blade.php
@@ -2,9 +2,11 @@
     'flex-1 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 bg-white px-4 py-10 sm:px-6 xl:px-8'
 ])>
     @if (!empty($label))
-        <dt {{ $label->attributes->class(['text-sm font-medium leading-6 text-gray-500']) }}>
+        <ui:description tag="dt" :attributes="$label->attributes->class([
+            'text-sm font-medium leading-6 opacity-40',
+        ])">
             {{ $label }}
-        </dt>
+        </ui:description>
     @endif
 
     @if (!empty($description))
@@ -13,7 +15,9 @@
         </dd>
     @endif
 
-    <dd class="w-full flex-none text-3xl font-medium leading-10 tracking-tight text-gray-900">
+    <ui:heading tag="dd" size="lg" :attributes="$slot->attributes->class([
+        'w-full flex-none leading-10',
+    ])">
         {{ $slot }}
-    </dd>
+    </ui:heading>
 </div>

--- a/resources/views/components/tiles.blade.php
+++ b/resources/views/components/tiles.blade.php
@@ -1,8 +1,15 @@
 @use('Bearly\Ui\Size')
-@props(['gap' => Size::BASE])
+@use('Bearly\Ui\Variant')
+
+@props([
+    'gap' => Size::BASE,
+    'variant' => Variant::Outline,
+])
 
 <dl {{ $attributes->class([
     'mx-auto flex flex-col bg-gray-900/5 sm:flex-row',
+    'bg-gray-900/5' => Variant::Solid->is($variant),
+    'bg-transparent' => Variant::Outline->is($variant) || Variant::Ghost->is($variant),
     'gap-px' => Size::BASE->is($gap),
     'gap-0.5' => Size::MD->is($gap),
     'gap-1' => Size::LG->is($gap),

--- a/resources/views/components/tiles.blade.php
+++ b/resources/views/components/tiles.blade.php
@@ -1,0 +1,10 @@
+@props(['gap' => Size::BASE])
+
+<dl {{ $attributes->class([
+    'mx-auto flex flex-col gap-px bg-gray-900/5 sm:flex-row',
+    'gap-2' => Size::SM->is($gap),
+    'gap-px' => Size::BASE->is($gap),
+    'gap-4' => Size::LG->is($gap),
+]) }}>
+    {{ $slot }}
+</dl>

--- a/resources/views/components/tiles.blade.php
+++ b/resources/views/components/tiles.blade.php
@@ -1,10 +1,11 @@
+@use('Bearly\Ui\Size')
 @props(['gap' => Size::BASE])
 
 <dl {{ $attributes->class([
-    'mx-auto flex flex-col gap-px bg-gray-900/5 sm:flex-row',
-    'gap-2' => Size::SM->is($gap),
+    'mx-auto flex flex-col bg-gray-900/5 sm:flex-row',
     'gap-px' => Size::BASE->is($gap),
-    'gap-4' => Size::LG->is($gap),
+    'gap-0.5' => Size::MD->is($gap),
+    'gap-1' => Size::LG->is($gap),
 ]) }}>
     {{ $slot }}
 </dl>


### PR DESCRIPTION
This PR tweaks several things after being used in our work project. 

- Lightens the over state on the `ghost+secondary` button variant+color combination
- Give users an easy way to opt out of card padding
- Allow `ui:description` to also be any tag such as `dd` or `dt` (like heading does)
- Added `ui:link` component
- Added `ui:tiles` component
- Added `ui:tile` component