### PR TITLE
Improve / redesign dialogs - AC-172

### DIFF
--- a/docs/dialogs.md
+++ b/docs/dialogs.md
@@ -89,6 +89,20 @@ Custom header content for the dialog. If not provided, a default close button wi
 </x-slot:header>
 ```
 
+```html +demo title={Dialog with Header}
+<ui:dialog>
+    <x-slot:trigger>
+        <ui:button>Example - Header slot</ui:button>
+    </x-slot:trigger>
+
+    <x-slot:header>
+        <ui:heading>There are no mistakes</ui:heading>
+    </x-slot:header>
+
+    <p class="min-h-[200px] text-center mt-20">We'll play with clouds today.</p>
+</ui:dialog>
+```
+
 ### default
 
 The main content of the dialog.
@@ -111,6 +125,19 @@ Optional footer content for the dialog.
 </x-slot:footer>
 ```
 
+```html +demo title={Dialog with Header}
+<ui:dialog>
+    <x-slot:trigger>
+        <ui:button>Example - Footer slot</ui:button>
+    </x-slot:trigger>
+
+    <p class="min-h-[200px] text-center mt-20">We'll play with clouds today.</p>
+
+    <x-slot:footer>
+        I'm a footer, put buttons in me!
+    </x-slot:footer>
+</ui:dialog>
+```
 
 ## Accessibility
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,6 +61,7 @@ export default {
     "./resources/**/*.blade.php",
     "./resources/**/*.js",
     './vendor/bearly/ui/**/*.{php,blade.php}', // [tl! add] [tl! focus]
+    './vendor/bearly/ui/js/**/*.js', // [tl! add] [tl! focus]
   ], // [tl! focus]
   theme: { // [tl! focus]
     extend: { // [tl! focus]

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -52,6 +52,31 @@ export default function(Alpine) {
             'x-ref': 'close',
             'x-on:click': 'closeDialog',
             'x-effect'() { return this.open && setTimeout(() => this.$el.removeAttribute('inert'), 100) },
+        },
+
+        uiDialogMobileDragToClose: {
+            'x-data'() {
+                return {
+                    start: null,
+                    current: null,
+                    dragging: false,
+                    get distance() {
+                        return this.dragging ? Math.max(0, this.current - this.start) : 0
+                    },
+                }
+            },
+            'x-on:touchstart'(event) {
+                this.dragging = true
+                this.start = this.current = event.touches[0].clientY
+            },
+            'x-on:touchmove'(event) { this.current = event.touches[0].clientY },
+            'x-on:touchend'() {
+                if (this.distance > 100) {
+                    this.closeDialog()
+                    this.dragging = false
+                }
+            },
+            'x-effect'() { this.$el.parentElement.style.transform = `translateY(${this.distance}px)` },
         }
     }))
 }

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -41,9 +41,9 @@ export default function(Alpine) {
             'aria-modal': true,
             'x-ref': 'content',
             'x-show'() { return this.open },
-            'x-transition:enter': 'transition ease-out duration-150 delay-75 origin-bottom',
-            'x-transition:enter-start': 'opacity-0 transform scale-90 translate-y-4',
-            'x-transition:enter-end': 'opacity-100 transform scale-100 translate-y-0',
+            'x-transition:enter': 'transition-all ease-out delay-75 origin-bottom',
+            'x-transition:enter-start': 'translate-y-full sm:opacity-0 sm:scale-90 sm:translate-y-4',
+            'x-transition:enter-end': 'translate-y-0 sm:opacity-100 sm:scale-100 sm:translate-y-0',
             'x-transition:leave.duration.0ms.delay.0ms': '',
         },
 

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -44,7 +44,7 @@ export default function(Alpine) {
             'x-transition:enter': 'transition-all ease-out origin-bottom',
             'x-transition:enter-start': 'translate-y-full sm:opacity-0 sm:scale-90 sm:translate-y-4',
             'x-transition:enter-end': 'translate-y-0 sm:opacity-100 sm:scale-100 sm:translate-y-0',
-            // 'x-transition:leave.duration.0ms.delay.0ms': '',
+            'x-transition:leave': 'duration-0 delay-0',
         },
 
         uiDialogClose: {

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -41,10 +41,10 @@ export default function(Alpine) {
             'aria-modal': true,
             'x-ref': 'content',
             'x-show'() { return this.open },
-            'x-transition:enter': 'transition-all ease-out delay-75 origin-bottom',
+            'x-transition:enter': 'transition-all ease-out origin-bottom',
             'x-transition:enter-start': 'translate-y-full sm:opacity-0 sm:scale-90 sm:translate-y-4',
             'x-transition:enter-end': 'translate-y-0 sm:opacity-100 sm:scale-100 sm:translate-y-0',
-            'x-transition:leave.duration.0ms.delay.0ms': '',
+            // 'x-transition:leave.duration.0ms.delay.0ms': '',
         },
 
         uiDialogClose: {

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -31,7 +31,7 @@
 
             {{-- Sizing --}}
             'px-1.5 py-1 text-xs' => Size::XS->is($size),
-            'px-3 py-1.5 text-sm font-medium' => Size::SM->is($size),
+            'px-2 py-1.5 text-sm font-medium' => Size::SM->is($size),
             'px-4 py-2 text-sm font-medium' => Size::BASE->is($size),
             'px-5 py-2.5 text-base font-medium' => Size::MD->is($size),
             'px-6 py-3 text-lg font-medium' => Size::LG->is($size),

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -104,7 +104,11 @@
                         tabindex="-1"
                         aria-hidden="true"
                         x-bind="uiDialogMobileDragToClose"
-                        class="sm:hidden bg-black/10 dark:bg-white/15 w-10 h-1 rounded-full absolute mx-auto left-0 right-0 top-4"
+                        @class([
+                            'sm:hidden bg-black/10 dark:bg-white/15 w-10 h-1 rounded-full absolute mx-auto left-0 right-0',
+                            'top-4' => empty($header),
+                            'top-1' => !empty($header),
+                        ])
                     >
                         <span class="block relative h-10 -mt-5 w-full"></span>
                     </button>

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -41,20 +41,11 @@
                     'sm:max-w-full' => $size === 'full',
                 ])
             >
+
                 {{-- Card --}}
                 <ui:card
                     class="relative w-full max-w-full max-h-[96vh] overflow-y-auto ring-1 ring-black/5 dark:ring-white/5 rounded-none sm:rounded shadow-lg dark:shadow-2xl {{ $cardClass }}"
                 >
-                    {{-- Mobile drag-to-close --}}
-                    <button
-                        type="button"
-                        tabindex="-1"
-                        aria-hidden="true"
-                        x-bind="uiDialogMobileDragToClose"
-                        class="sm:hidden bg-black/10 dark:bg-white/15 w-10 h-1 rounded-full absolute mx-auto left-0 right-0 top-1.5"
-                    >
-                        <span class="block relative h-6 -mt-3 w-full"></span>
-                    </button>
 
                     {{-- Header --}}
                     @empty($header)
@@ -105,7 +96,20 @@
                     @if ($footer ?? false)
                         <x-slot:footer>{{ $footer }}</x-slot:footer>
                     @endif
+
+                    {{-- Mobile drag-to-close --}}
+                    {{-- Expects to be IN card --}}
+                    <button
+                        type="button"
+                        tabindex="-1"
+                        aria-hidden="true"
+                        x-bind="uiDialogMobileDragToClose"
+                        class="sm:hidden bg-black/10 dark:bg-white/15 w-10 h-1 rounded-full absolute mx-auto left-0 right-0 top-4"
+                    >
+                        <span class="block relative h-10 -mt-5 w-full"></span>
+                    </button>
                 </x-card>
+
             </div>
         </div>
     </template>

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -47,20 +47,11 @@
                 >
                     {{-- Mobile drag-to-close --}}
                     <button
-                        x-data="{
-                            start: null,
-                            current: null,
-                            dragging: false,
-                            get distance() {
-                                return this.dragging ? Math.max(0, this.current - this.start) : 0
-                            },
-                        }"
                         type="button"
+                        tabindex="-1"
+                        aria-hidden="true"
+                        x-bind="uiDialogMobileDragToClose"
                         class="sm:hidden bg-black/10 dark:bg-white/15 w-10 h-1 rounded-full absolute mx-auto left-0 right-0 top-1.5"
-                        x-on:touchstart="dragging = true; start = current = $event.touches[0].clientY"
-                        x-on:touchmove="current = $event.touches[0].clientY"
-                        x-on:touchend="if (distance > 100) closeDialog(); dragging = false"
-                        x-effect="$el.parentElement.style.transform = 'translateY('+distance+'px)'"
                     >&nbsp;</button>
 
                     {{-- Header --}}

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -33,7 +33,7 @@
             <div
                 x-bind="uiDialogContent"
                 @class([
-                    'rounded flex-1 shadow-lg relative not-prose mx-auto max-w-full w-full max-h-[96vh] overflow-y-auto ring-1 ring-black/5 dark:ring-gray-700/60',
+                    'flex-1 relative not-prose mx-auto max-w-full w-full max-h-[96vh] sm:rounded',
                     'sm:max-w-xl' => $size === 'sm',
                     'sm:max-w-2xl' => $size === 'md',
                     'sm:max-w-4xl' => $size === 'lg',
@@ -43,7 +43,7 @@
             >
                 {{-- Card --}}
                 <ui:card
-                    class="relative w-full border border-black/10 !mb-0 rounded-b-none sm:rounded-b {{ $cardClass }}"
+                    class="relative w-full max-w-full max-h-[96vh] overflow-y-auto ring-1 ring-black/5 dark:ring-white/5 rounded-none sm:rounded shadow-lg dark:shadow-2xl {{ $cardClass }}"
                 >
                     {{-- Mobile drag-to-close --}}
                     <button

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -52,7 +52,9 @@
                         aria-hidden="true"
                         x-bind="uiDialogMobileDragToClose"
                         class="sm:hidden bg-black/10 dark:bg-white/15 w-10 h-1 rounded-full absolute mx-auto left-0 right-0 top-1.5"
-                    >&nbsp;</button>
+                    >
+                        <span class="block relative h-6 -mt-3 w-full"></span>
+                    </button>
 
                     {{-- Header --}}
                     @empty($header)

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -56,7 +56,7 @@
                             },
                         }"
                         type="button"
-                        class="sm:hidden bg-black/10 w-10 h-1 rounded-full absolute mx-auto left-0 right-0 top-1.5"
+                        class="sm:hidden bg-black/10 dark:bg-white/15 w-10 h-1 rounded-full absolute mx-auto left-0 right-0 top-1.5"
                         x-on:touchstart="dragging = true; start = current = $event.touches[0].clientY"
                         x-on:touchmove="current = $event.touches[0].clientY"
                         x-on:touchend="if (distance > 100) closeDialog(); dragging = false"

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -140,7 +140,7 @@ class Install extends Command
 
     protected function ensureTailwindConfigHasUiVendorContent()
     {
-        $this->ensureJsFileHasValues('tailwind.config.js', 'content', ["'./resources/**/*.blade.php'", "'./app/**/*.php'", "'./vendor/bearly/ui/**/*.{php,blade.php}'"]);
+        $this->ensureJsFileHasValues('tailwind.config.js', 'content', ["'./resources/**/*.blade.php'", "'./app/**/*.php'", "'./vendor/bearly/ui/**/*.{php,blade.php}'", "'./vendor/bearly/ui/js/**/*.js'"]);
     }
 
     protected function ensureTailwindConfigHasColorsExtended()


### PR DESCRIPTION
- **BUGFIX:** added javascript files to Tailwind's `content` path. 
- Improved mobile drag-to-close tap area, behavior, and code abstraction
- Fixed design of drag-to-close in dark mode and with-header-on-mobile scenarios
- Improved docs with better examples
- Fixed mobile transitions to be bottom-up