### PR TITLE
Improve dialog header/footer usability | AC-196

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 - Changed sizing scale for many components to improve clarity
 - Removed nested `<span>` elements from buttons
 - Changed loading indicator logic to target wire clicks automatically
+- Dialog header and footer slots now forward attributes to card slots
+- Add `when` attribute to card (and dialog) header and footer slots to conditionally show them
 
 ## 0.5.2
 

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -24,7 +24,7 @@
 
     {{-- Header --}}
     @if ($header ?? false)
-        <div {{ $header->attributes->class([
+        <div data-ui-card-header {{ $header->attributes->class([
             'rounded-t border-b bg-gray-100/60 dark:bg-black/5 border-gray-900/5 dark:border-gray-50/10',
             'px-5 py-2' => Size::NONE->is($padding),
             '-mx-3 -mt-3 mb-3 px-3 py-2' => Size::SM->is($padding),
@@ -41,7 +41,7 @@
 
     {{-- Footer --}}
     @if ($footer ?? false)
-        <div {{ $footer->attributes->class([
+        <div data-ui-card-footer {{ $footer->attributes->class([
             'border-t bg-gray-100/60 dark:bg-black/5 rounded-b border-gray-900/5 dark:border-gray-50/10',
             'px-5 py-2' => Size::NONE->is($padding),
             '-mx-3 -mb-3 mt-3 px-3 py-2' => Size::SM->is($padding),

--- a/resources/views/components/card.blade.php
+++ b/resources/views/components/card.blade.php
@@ -31,6 +31,7 @@
             '-mx-4 -mt-4 mb-4 px-4 py-2' => Size::MD->is($padding),
             '-mx-5 -mt-5 mb-5 px-5 py-3' => Size::LG->is($padding),
             '-mx-6 -mt-6 mb-6 px-6 py-3.5' => Size::XL->is($padding),
+            'hidden' => $header->attributes?->get('when') === false,
         ]) }}>
             {{ $header }}
         </div>
@@ -48,6 +49,7 @@
             '-mx-4 -mb-4 mt-4 px-4 py-2' => Size::MD->is($padding),
             '-mx-5 -mb-5 mt-5 px-5 py-3' => Size::LG->is($padding),
             '-mx-6 -mb-6 mt-6 px-6 py-3.5' => Size::XL->is($padding),
+            'hidden' => $footer->attributes?->get('when') === false,
         ]) }}>
             {{ $footer }}
         </div>

--- a/resources/views/components/dialog.blade.php
+++ b/resources/views/components/dialog.blade.php
@@ -51,10 +51,8 @@
 
                     {{-- Header --}}
                     @if (!empty($header))
-                        <x-slot:header>
-                            <div {{ $header->attributes->class(['text-gray-800 dark:text-gray-200']) }} >
-                                {{ $header }}
-                            </div>
+                        <x-slot:header :attributes="$header->attributes->class(['text-gray-800 dark:text-gray-200'])">
+                            {{ $header }}
                         </x-slot:header>
                     @endif
 
@@ -63,7 +61,7 @@
 
                     {{-- Footer --}}
                     @if ($footer ?? false)
-                        <x-slot:footer>{{ $footer }}</x-slot:footer>
+                        <x-slot:footer :attributes="$footer->attributes">{{ $footer }}</x-slot:footer>
                     @endif
 
                     {{-- Mobile drag-to-close --}}

--- a/tests/Browser/CardTest.php
+++ b/tests/Browser/CardTest.php
@@ -96,4 +96,27 @@ class CardTest extends BrowserTestCase
             ->assertHasClass('@outer', '*:data-ui-card:bg-gray-50/60')
             ->assertHasClass('@outer', 'dark:*:data-ui-card:bg-gray-700/30');
     }
+
+    public function test_header_and_footer_when_conditions()
+    {
+        $this->blade(<<<'HTML'
+            <ui:card dusk="card">
+                <x-slot:header dusk="header" :when="true">Header</x-slot:header>
+                Card Content
+                <x-slot:footer dusk="footer" :when="true">Footer</x-slot:footer>
+            </ui:card>
+        HTML)
+            ->assertVisible('@header')
+            ->assertVisible('@footer');
+
+        $this->blade(<<<'HTML'
+            <ui:card dusk="card">
+                <x-slot:header dusk="header" :when="false">Header</x-slot:header>
+                Card Content
+                <x-slot:footer dusk="footer" :when="false">Footer</x-slot:footer>
+            </ui:card>
+        HTML)
+            ->assertNotVisible('@header')
+            ->assertNotVisible('@footer');
+    }
 }

--- a/tests/Browser/DialogTest.php
+++ b/tests/Browser/DialogTest.php
@@ -228,6 +228,28 @@ class DialogTest extends BrowserTestCase
             ->assertHasClass('[data-ui-card]', 'test-card-class');
     }
 
+    public function test_header_and_footer_classes()
+    {
+        $this->blade(<<<'HTML'
+            <ui:dialog dusk="dialog">
+                <x-slot:trigger>
+                    <ui:button dusk="trigger">Open Dialog</ui:button>
+                </x-slot:trigger>
+                <x-slot:header class="text-center">
+                    <ui:heading>Dialog Header</ui:heading>
+                </x-slot:header>
+                Dialog Content
+                <x-slot:footer class="flex justify-end">
+                    <ui:button>Right aligned footer</ui:button>
+                </x-slot:footer>
+            </ui:dialog>
+        HTML)
+            ->click('@trigger')
+            ->waitForText('Dialog Header')
+            ->assertHasClass('[data-ui-card-header]', 'text-center')
+            ->assertHasClass('[data-ui-card-footer]', 'justify-end');
+    }
+
     public function test_headings_and_subheadings_are_bound_to_aria_labelledby_and_describedby()
     {
         $this->blade(<<<'HTML'


### PR DESCRIPTION
- Dialog header and footer slots now forward attributes to card slots
- Add `when` attribute to card (and dialog) header and footer slots to conditionally show them